### PR TITLE
SMTP.SendEmail - Add OAuth support

### DIFF
--- a/Frends.SMTP.SendEmail/CHANGELOG.md
+++ b/Frends.SMTP.SendEmail/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.2.0] - 2023-12-21
+### Changed
+- Changed Task to use MailKit library instead of deprecated System.Net.Mail.
+- Changed the Task to create a temp file from the AttachmentFromString. The temp file will be removed afterwards.
+
+### Added
+- Added OAuth2 support.
+- New parameters:
+	- SecureSocket
+	- UseOAuth2
+	- Token
+
+### Removed
+- Removed UseWindowsAuthentication because it's not supported with the new library.
+
 ## [1.1.0] - 2023-11-29
 ### Fixed
 - [Breaking] Fixed issue with the attachments can't be given as expression by adding AttachmentOptions class.

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
@@ -16,7 +16,6 @@ public class SendEmailTests
     private static readonly string TOEMAILADDRESS = Environment.GetEnvironmentVariable("Frends_SMTP_Email");
     private static readonly string FROMEMAILADDRESS = Environment.GetEnvironmentVariable("Frends_SMTP_Email");
     private const int PORT = 587;
-    private const bool USESSL = true;
     // ************************************************************************************************************
 
 
@@ -75,7 +74,8 @@ public class SendEmailTests
             Password = PASSWORD,
             SMTPServer = SMTPADDRESS,
             Port = PORT,
-            UseSsl = USESSL,
+            UseOAuth2 = false,
+            SecureSocket = SecureSocketOption.None
         };
 
     }
@@ -191,7 +191,6 @@ public class SendEmailTests
         var Attachments = new AttachmentOptions { Attachments = new Attachment[] { attachment } };
 
         var ex = Assert.ThrowsAsync<FileNotFoundException>(async () => await SMTP.SendEmail(input, Attachments, _options, default));
-        Assert.AreEqual("", ex.Message);
-
+        Assert.AreEqual(@"The given filepath 'C:\Users\virtari\AppData\Local\Temp\emailtestattachments\doesntexist.txt' had no matching files", ex.Message);
     }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
@@ -79,6 +79,7 @@ public class SendEmailTests
         };
 
     }
+
     [TearDown]
     public void EmailTestTearDown()
     {
@@ -191,6 +192,6 @@ public class SendEmailTests
         var Attachments = new AttachmentOptions { Attachments = new Attachment[] { attachment } };
 
         var ex = Assert.ThrowsAsync<FileNotFoundException>(async () => await SMTP.SendEmail(input, Attachments, _options, default));
-        Assert.AreEqual(@"The given filepath 'C:\Users\virtari\AppData\Local\Temp\emailtestattachments\doesntexist.txt' had no matching files", ex.Message);
+        Assert.AreEqual(@$"The given filepath '{attachment.FilePath}' had no matching files", ex.Message);
     }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using Frends.SMTP.SendEmail.Definitions;
 
 namespace Frends.SMTP.SendEmail.Tests;
@@ -16,7 +17,6 @@ public class SendEmailTests
     private static readonly string FROMEMAILADDRESS = Environment.GetEnvironmentVariable("Frends_SMTP_Email");
     private const int PORT = 587;
     private const bool USESSL = true;
-    private const bool USEWINDOWSAUTHENTICATION = false;
     // ************************************************************************************************************
 
 
@@ -76,7 +76,6 @@ public class SendEmailTests
             SMTPServer = SMTPADDRESS,
             Port = PORT,
             UseSsl = USESSL,
-            UseWindowsAuthentication = USEWINDOWSAUTHENTICATION,
         };
 
     }
@@ -88,17 +87,17 @@ public class SendEmailTests
     }
 
     [Test]
-    public void SendEmailWithPlainText()
+    public async Task SendEmailWithPlainText()
     {
         var input = _input;
         input.Subject = "Email test - PlainText";
 
-        var result = SMTP.SendEmail(input, null, _options, default);
+        var result = await SMTP.SendEmail(input, null, _options, default);
         Assert.IsTrue(result.EmailSent);
     }
 
     [Test]
-    public void SendEmailWithFileAttachment()
+    public async Task SendEmailWithFileAttachment()
     {
         var input = _input;
         input.Subject = "Email test - FileAttachment";
@@ -114,12 +113,12 @@ public class SendEmailTests
 
         var Attachments = new AttachmentOptions { Attachments = new Attachment[] { attachment } };
 
-        var result = SMTP.SendEmail(input, Attachments, _options, default);
+        var result = await SMTP.SendEmail(input, Attachments, _options, default);
         Assert.IsTrue(result.EmailSent);
     }
 
     [Test]
-    public void SendEmailWithStringAttachment()
+    public async Task SendEmailWithStringAttachment()
     {
         var input = _input;
         input.Subject = "Email test - AttachmentFromString";
@@ -131,12 +130,12 @@ public class SendEmailTests
         };
         var Attachments = new AttachmentOptions { Attachments = new Attachment[] { attachment } };
 
-        var result = SMTP.SendEmail(input, Attachments, _options, default);
+        var result = await SMTP.SendEmail(input, Attachments, _options, default);
         Assert.IsTrue(result.EmailSent);
     }
 
     [Test]
-    public void TrySendingEmailWithNoFileAttachmentFound()
+    public async Task TrySendingEmailWithNoFileAttachmentFound()
     {
         var input = _input;
         input.Subject = "Email test";
@@ -151,12 +150,12 @@ public class SendEmailTests
 
         var Attachments = new AttachmentOptions { Attachments = new Attachment[] { attachment } };
 
-        var result = SMTP.SendEmail(input, Attachments, _options, default);
+        var result = await SMTP.SendEmail(input, Attachments, _options, default);
         Assert.IsFalse(result.EmailSent);
     }
 
     [Test]
-    public void TrySendingEmailWithNoCcAndBcc()
+    public async Task TrySendingEmailWithNoCcAndBcc()
     {
         var input = _input2;
         input.Subject = "Email test";
@@ -171,7 +170,7 @@ public class SendEmailTests
 
         var Attachments = new AttachmentOptions { Attachments = new Attachment[] { attachment } };
 
-        var result = SMTP.SendEmail(input, Attachments, _options, default);
+        var result = await SMTP.SendEmail(input, Attachments, _options, default);
         Assert.IsFalse(result.EmailSent);
     }
 
@@ -191,7 +190,8 @@ public class SendEmailTests
 
         var Attachments = new AttachmentOptions { Attachments = new Attachment[] { attachment } };
 
-        Assert.Throws<FileNotFoundException>(() => SMTP.SendEmail(input, Attachments, _options, default));
+        var ex = Assert.ThrowsAsync<FileNotFoundException>(async () => await SMTP.SendEmail(input, Attachments, _options, default));
+        Assert.AreEqual("", ex.Message);
 
     }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Attachment.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Attachment.cs
@@ -11,11 +11,13 @@ public class Attachment
     /// <summary>
     /// Chooses if the attachment file is created from a string or copied from disk.
     /// </summary>
+    /// <example>AttachmentType.FileAttachment</example>
     public AttachmentType AttachmentType { get; set; }
 
     /// <summary>
     /// Attachment from string.
     /// </summary>
+    /// <example>AttachmentFromString { "Test file content", "testFile.txt" }</example>
     [UIHint(nameof(AttachmentType), "", AttachmentType.AttachmentFromString)]
     public AttachmentFromString StringAttachment { get; set; }
 
@@ -23,6 +25,7 @@ public class Attachment
     /// Attachment file's path. Uses Directory.GetFiles(string, string) as a pattern matching technique. See https://msdn.microsoft.com/en-us/library/wz42302f(v=vs.110).aspx.
     /// Exception: If the path ends in a directory, all files in that folder are added as attachments.
     /// </summary>
+    /// <example>C:\path\to\file.txt</example>
     [DefaultValue("")]
     [UIHint(nameof(AttachmentType), "", AttachmentType.FileAttachment)]
     public string FilePath { get; set; }
@@ -30,12 +33,14 @@ public class Attachment
     /// <summary>
     /// If set true and no files match the given path, an exception is thrown.
     /// </summary>
+    /// <example>true</example>
     [UIHint(nameof(AttachmentType), "", AttachmentType.FileAttachment)]
     public bool ThrowExceptionIfAttachmentNotFound { get; set; }
 
     /// <summary>
     /// If set true and no files match the given path, email will be sent nevertheless.
     /// </summary>
+    /// <example>true</example>
     [UIHint(nameof(AttachmentType), "", AttachmentType.FileAttachment)]
     public bool SendIfNoAttachmentsFound { get; set; }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Input.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Input.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace Frends.SMTP.SendEmail.Definitions;
 
@@ -11,6 +12,7 @@ public class Input
     /// Recipient addresses separated by ',' or ';'
     /// </summary>
     /// <example>jane.doe@somedomain.com</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("jane.doe@somedomain.com")]
     public string To { get; set; }
 
@@ -18,6 +20,7 @@ public class Input
     /// Cc recipient addresses separated by ',' or ';'
     /// </summary>
     /// <example>jane.doe@somedomain.com</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("jane.doe@somedomain.com")]
     public string Cc { get; set; }
 
@@ -25,6 +28,7 @@ public class Input
     /// Bcc recipient addresses separated by ',' or ';'
     /// </summary>
     /// <example>jane.doe@somedomain.com</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("jane.doe@somedomain.com")]
     public string Bcc { get; set; }
 
@@ -32,6 +36,7 @@ public class Input
     /// Sender address.
     /// </summary>
     /// <example>jane.doe@somedomain.com</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("john.doe@somedomain.com")]
     public string From { get; set; }
 
@@ -39,6 +44,7 @@ public class Input
     /// Name of the sender.
     /// </summary>
     /// <example>Jane Doe</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("")]
     public string SenderName { get; set; }
 
@@ -46,13 +52,15 @@ public class Input
     /// Email message's subject.
     /// </summary>
     /// <example>Hello Jane</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("Hello Jane")]
     public string Subject { get; set; }
 
     /// <summary>
     /// Body of the message.
     /// </summary>
-    /// <exmaple>You've got mail!</exmaple>
+    /// <example>You've got mail!</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("You've got mail!")]
     public string Message { get; set; }
 
@@ -67,6 +75,7 @@ public class Input
     /// Encoding of message body and subject. Use following table's name column for other options. https://msdn.microsoft.com/en-us/library/system.text.encoding(v=vs.110).aspx#Anchor_5 
     /// </summary>
     /// <example>utf-8</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("utf-8")]
     public string MessageEncoding { get; set; }
 

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -30,18 +30,27 @@ public class Options
     public bool UseSsl { get; set; }
 
     /// <summary>
-    /// Set this true if you want to use windows authentication to authenticate to SMTP server.
+    /// Set this true if SMTP server expectes OAuth token.
     /// </summary>
-    /// <example>false</example>
-    [DefaultValue("true")]
-    public bool UseWindowsAuthentication { get; set; }
+    /// <example>true</example>
+    [DefaultValue(false)]
+    public bool UseOAuth2 { get; set; }
+
+    /// <summary>
+    /// Token to be used when using OAuth2.
+    /// </summary>
+    /// <example>cec4ce4f98e4f68e4vc89v1489v4987s4erv8794...</example>
+    [DisplayFormat(DataFormatString = "Text")]
+    [UIHint(nameof(UseOAuth2), "", true)]
+    [PasswordPropertyText]
+    public string Token { get; set; }
 
     /// <summary>
     /// Use this username to log in to the SMTP server
     /// </summary>
     /// <example>testuser</example>
     [DefaultValue("")]
-    [UIHint(nameof(UseWindowsAuthentication), "", false)]
+    [UIHint(nameof(UseOAuth2), "", false)]
     public string UserName { get; set; }
 
     /// <summary>
@@ -50,6 +59,6 @@ public class Options
     /// <example>Password123</example>
     [PasswordPropertyText(true)]
     [DefaultValue("")]
-    [UIHint(nameof(UseWindowsAuthentication), "", false)]
+    [UIHint(nameof(UseOAuth2), "", false)]
     public string Password { get; set; }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -23,11 +23,11 @@ public class Options
     public int Port { get; set; }
 
     /// <summary>
-    /// Set this true if SMTP expects to be connected using SSL.
+    /// Choose the SecureSocketOption to use, default is Auto
     /// </summary>
-    /// <exmaple>true</exmaple>
-    [DefaultValue("false")]
-    public bool UseSsl { get; set; }
+    /// <example>SecureSocketOption.None</example>
+    [DefaultValue(SecureSocketOption.Auto)]
+    public SecureSocketOption SecureSocket { get; set; }
 
     /// <summary>
     /// Set this true if SMTP server expectes OAuth token.

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -12,6 +12,7 @@ public class Options
     /// SMTP server address.
     /// </summary>
     /// <example>smtp.somedomain.com</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("smtp.somedomain.com")]
     public string SMTPServer { get; set; }
 
@@ -49,8 +50,8 @@ public class Options
     /// Use this username to log in to the SMTP server
     /// </summary>
     /// <example>testuser</example>
+    [DisplayFormat(DataFormatString = "Text")]
     [DefaultValue("")]
-    [UIHint(nameof(UseOAuth2), "", false)]
     public string UserName { get; set; }
 
     /// <summary>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/SecureSocketOption.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/SecureSocketOption.cs
@@ -1,0 +1,32 @@
+﻿namespace Frends.SMTP.SendEmail.Definitions;
+
+/// <summary>
+/// Secure Socket Options.
+/// </summary>
+public enum SecureSocketOption
+{
+    /// <summary>
+    /// No SSL or TLS encryption should be used. 
+    /// </summary>
+    None,
+    /// <summary>
+    /// Allow the IMailService to decide which SSL or TLS options to use (default). 
+    /// If the server does not support SSL or TLS, then the connection will continue without any encryption.
+    /// </summary>
+    Auto,
+    /// <summary>
+    /// The connection should use SSL or TLS encryption immediately.
+    /// </summary>
+    SslOnConnect,
+    /// <summary>
+    /// Elevates the connection to use TLS encryption immediately after reading the greeting and capabilities of 
+    /// the server. If the server does not support the STARTTLS extension, then the connection will fail and a 
+    /// NotSupportedException will be thrown.
+    /// </summary>
+    StartTls,
+    /// <summary>
+    /// Elevates the connection to use TLS encryption immediately after reading the greeting and capabilities of 
+    /// the server, but only if the server supports the STARTTLS extension.
+    /// </summary>
+    StartTlsWhenAvailable
+}

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
   <TargetFramework>net6.0</TargetFramework>
-	<Version>1.1.3</Version>
+	<Version>1.2.0</Version>
 	<LangVersion>latest</LangVersion>
 	<Authors>Frends</Authors>
 	<Company>Frends</Company>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
@@ -1,9 +1,8 @@
-﻿
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
   <TargetFramework>net6.0</TargetFramework>
-	<Version>1.1.0</Version>
+	<Version>1.1.3</Version>
 	<LangVersion>latest</LangVersion>
 	<Authors>Frends</Authors>
 	<Company>Frends</Company>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
@@ -24,6 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+	<PackageReference Include="MailKit" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -2,10 +2,15 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Net;
-using System.Net.Mail;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using MimeKit.Text;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Frends.SMTP.SendEmail.Definitions;
 
 namespace Frends.SMTP.SendEmail;
@@ -18,16 +23,24 @@ public static class SMTP
     /// Sends email message with optional attachments.
     /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.SMTP.SendEmail)
     /// </summary>
-    /// <param name="message">Message parameters.</param>
+    /// <param name="input">Message parameters.</param>
     /// <param name="attachments">Parameters for adding attachments.</param>
     /// <param name="SMTPSettings">Connection parameters.</param>
     /// <param name="cancellationToken">Token given by Frends to terminate the Task.</param>
     /// <returns>Object { bool EmailSent, string StatusString }</returns>
-    public static Result SendEmail([PropertyTab] Input message, [PropertyTab] AttachmentOptions attachments, [PropertyTab] Options SMTPSettings, CancellationToken cancellationToken)
+    public static async Task<Result> SendEmail([PropertyTab] Input input, [PropertyTab] AttachmentOptions attachments, [PropertyTab] Options SMTPSettings, CancellationToken cancellationToken)
     {
-        using var client = InitializeSmtpClient(SMTPSettings);
-        using var mail = InitializeMailMessage(message, cancellationToken);
-        if (attachments != null)
+        using var mail = InitializeMimeMessage(input);
+
+        if (attachments != null && attachments.Attachments.Length > 0)
+        {
+            var builder = new BodyBuilder();
+
+            if (input.IsMessageHtml)
+                builder.HtmlBody = input.Message;
+            else
+                builder.TextBody = input.Message;
+
             foreach (var attachment in attachments.Attachments)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -37,25 +50,45 @@ public static class SMTP
                     ICollection<string> allAttachmentFilePaths = GetAttachmentFiles(attachment.FilePath);
 
                     if (attachment.ThrowExceptionIfAttachmentNotFound && allAttachmentFilePaths.Count == 0)
-                        throw new FileNotFoundException($@"The given filepath ""attachment.FilePath"" had no matching files", attachment.FilePath);
+                        throw new FileNotFoundException($@"The given filepath '{attachment.FilePath}' had no matching files", attachment.FilePath);
 
                     if (allAttachmentFilePaths.Count == 0 && !attachment.SendIfNoAttachmentsFound)
-                        return new Result(false, $@"No attachments found matching path ""{attachment.FilePath}"". No email sent.");
+                        return new Result(false, $@"No attachments found matching path '{attachment.FilePath}'. No email sent.");
 
                     foreach (var fp in allAttachmentFilePaths)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
-                        mail.Attachments.Add(new System.Net.Mail.Attachment(fp));
+                        builder.Attachments.Add(fp, cancellationToken);
                     }
                 }
 
-                if (attachment.AttachmentType == AttachmentType.AttachmentFromString
-                    && !string.IsNullOrEmpty(attachment.StringAttachment.FileContent))
-                    mail.Attachments.Add(System.Net.Mail.Attachment.CreateAttachmentFromString
-                        (attachment.StringAttachment.FileContent, attachment.StringAttachment.FileName));
+                // Create attachment only if content is not empty.
+                if (attachment.AttachmentType == AttachmentType.AttachmentFromString && !string.IsNullOrEmpty(attachment.StringAttachment.FileContent))
+                {
+                    var path = CreateTemporaryFile(attachment);
+                    builder.Attachments.Add(path, cancellationToken);
+                    CleanUpTempWorkDir(path);
+                }
             }
+        }
+        else
+        {
+            //Set message encoding
+            Encoding encoding = Encoding.GetEncoding(input.MessageEncoding);
+
+            var body = (input.IsMessageHtml)
+                ? new TextPart(TextFormat.Html) { Text = input.Message }
+                : new TextPart(TextFormat.Plain) { Text = input.Message };
+            body.SetText(encoding, input.Message);
+            mail.Body = body;
+        }
+
+        using var client = new SmtpClient();
+
+        await ConnectAndAuthenticate(client, SMTPSettings, cancellationToken);
 
         client.Send(mail);
+        await client.DisconnectAsync(true, cancellationToken);
 
         return new Result(true, $"Email sent to: {mail.To}");
     }
@@ -63,72 +96,47 @@ public static class SMTP
     /// <summary>
     /// Initializes new SmtpClient with given parameters.
     /// </summary>
-    private static SmtpClient InitializeSmtpClient(Options settings)
+    private static async Task<bool> ConnectAndAuthenticate(SmtpClient client, Options settings, CancellationToken cancellationToken)
     {
-        var smtpClient = new SmtpClient
-        {
-            Port = settings.Port,
-            DeliveryMethod = SmtpDeliveryMethod.Network,
-            UseDefaultCredentials = settings.UseWindowsAuthentication,
-            EnableSsl = settings.UseSsl,
-            Host = settings.SMTPServer
-        };
+        await client.ConnectAsync(settings.SMTPServer, settings.Port, settings.UseSsl, cancellationToken);
 
-        if (!settings.UseWindowsAuthentication && !string.IsNullOrEmpty(settings.UserName))
-            smtpClient.Credentials = new NetworkCredential(settings.UserName, settings.Password);
+        SaslMechanism mechanism;
 
-        return smtpClient;
+        if (settings.UseOAuth2)
+            mechanism = new SaslMechanismOAuth2(settings.UserName, settings.Token);
+        else
+            mechanism = new SaslMechanismLogin(new NetworkCredential(settings.UserName, settings.Password)); 
+
+        await client.AuthenticateAsync(mechanism, cancellationToken);
+
+        return client.IsConnected && client.IsAuthenticated;
     }
 
     /// <summary>
     /// Initializes new MailMessage with given parameters. Uses default value 'true' for IsBodyHtml
     /// </summary>
-    private static MailMessage InitializeMailMessage(Input input, CancellationToken cancellationToken)
+    private static MimeMessage InitializeMimeMessage(Input input)
     {
         //split recipients, either by comma or semicolon
         var separators = new[] { ',', ';' };
 
-        string[] recipients = string.IsNullOrEmpty(input.To)
-            ? Array.Empty<string>()
-            : input.To.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-        string[] ccRecipients = string.IsNullOrEmpty(input.Cc)
-            ? Array.Empty<string>()
-            : input.Cc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
-        string[] bccRecipients = string.IsNullOrEmpty(input.Bcc)
-            ? Array.Empty<string>()
-            : input.Bcc.Split(separators, StringSplitOptions.RemoveEmptyEntries);
+        MailboxAddress[] recipients = string.IsNullOrEmpty(input.To)
+            ? Array.Empty<MailboxAddress>()
+            : input.To.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(x => MailboxAddress.Parse(x)).ToArray();
+        MailboxAddress[] ccRecipients = string.IsNullOrEmpty(input.Cc)
+            ? Array.Empty<MailboxAddress>()
+            : input.Cc.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(x => MailboxAddress.Parse(x)).ToArray();
+        MailboxAddress[] bccRecipients = string.IsNullOrEmpty(input.Bcc)
+            ? Array.Empty<MailboxAddress>()
+            : input.Bcc.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(x => MailboxAddress.Parse(x)).ToArray();
 
         //Create mail object
-        var mail = new MailMessage()
-        {
-            From = new MailAddress(input.From, input.SenderName),
-            Subject = input.Subject,
-            Body = input.Message,
-            IsBodyHtml = input.IsMessageHtml
-        };
-        //Add recipients
-        foreach (var recipientAddress in recipients)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            mail.To.Add(recipientAddress);
-        }
-        //Add CC recipients
-        foreach (var ccRecipient in ccRecipients)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            mail.CC.Add(ccRecipient);
-        }
-        //Add BCC recipients
-        foreach (var bccRecipient in bccRecipients)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            mail.Bcc.Add(bccRecipient);
-        }
-        //Set message encoding
-        Encoding encoding = Encoding.GetEncoding(input.MessageEncoding);
-
-        mail.BodyEncoding = encoding;
-        mail.SubjectEncoding = encoding;
+        var mail = new MimeMessage();
+        mail.From.Add(new MailboxAddress(input.From, input.SenderName));
+        mail.To.AddRange(recipients);
+        mail.Cc.AddRange(ccRecipients);
+        mail.Bcc.AddRange(bccRecipients);
+        mail.Subject = input.Subject;
 
         return mail;
     }
@@ -144,5 +152,40 @@ public static class SMTP
         string[] filePaths = Directory.GetFiles(folder, fileMask);
 
         return filePaths;
+    }
+
+    /// <summary>
+    /// Create temp file of attachment from string.
+    /// </summary>
+    /// <param name="attachment"></param>
+    private static string CreateTemporaryFile(Attachment attachment)
+    {
+        var TempWorkDirBase = InitializeTemporaryWorkPath();
+        var filePath = Path.Combine(TempWorkDirBase, attachment.StringAttachment.FileName);
+        var content = attachment.StringAttachment.FileContent;
+
+        using var sw = File.CreateText(filePath);
+        sw.Write(content);
+
+        return filePath;
+    }
+
+    /// <summary>
+    /// Remove the temporary workdir.
+    /// </summary>
+    /// <param name="tempWorkDir"></param>
+    private static void CleanUpTempWorkDir(string tempWorkDir)
+    {
+        if (!string.IsNullOrEmpty(tempWorkDir) && Directory.Exists(tempWorkDir)) Directory.Delete(tempWorkDir, true);
+    }
+
+    /// <summary>
+    /// Create temperary directory for temp file.
+    /// </summary>
+    private static string InitializeTemporaryWorkPath()
+    {
+        var tempWorkDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempWorkDir);
+        return tempWorkDir;
     }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -70,6 +70,8 @@ public static class SMTP
                     CleanUpTempWorkDir(path);
                 }
             }
+
+            mail.Body = builder.ToMessageBody();
         }
         else
         {
@@ -87,7 +89,7 @@ public static class SMTP
 
         await ConnectAndAuthenticate(client, SMTPSettings, cancellationToken);
 
-        client.Send(mail);
+        await client.SendAsync(mail, cancellationToken);
         await client.DisconnectAsync(true, cancellationToken);
 
         return new Result(true, $"Email sent to: {mail.To}");
@@ -113,7 +115,7 @@ public static class SMTP
         if (settings.UseOAuth2)
             mechanism = new SaslMechanismOAuth2(settings.UserName, settings.Token);
         else
-            mechanism = new SaslMechanismLogin(new NetworkCredential(settings.UserName, settings.Password)); 
+            mechanism = new SaslMechanismLogin(new NetworkCredential(settings.UserName, settings.Password));
 
         await client.AuthenticateAsync(mechanism, cancellationToken);
 
@@ -140,7 +142,8 @@ public static class SMTP
 
         //Create mail object
         var mail = new MimeMessage();
-        mail.From.Add(new MailboxAddress(input.From, input.SenderName));
+        mail.From.Add(new MailboxAddress(input.SenderName, input.From));
+        mail.Sender = new MailboxAddress(input.SenderName, input.From);
         mail.To.AddRange(recipients);
         mail.Cc.AddRange(ccRecipients);
         mail.Bcc.AddRange(bccRecipients);

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -98,7 +98,15 @@ public static class SMTP
     /// </summary>
     private static async Task<bool> ConnectAndAuthenticate(SmtpClient client, Options settings, CancellationToken cancellationToken)
     {
-        await client.ConnectAsync(settings.SMTPServer, settings.Port, settings.UseSsl, cancellationToken);
+        var secureSocketOption = settings.SecureSocket switch
+        {
+            SecureSocketOption.None => SecureSocketOptions.None,
+            SecureSocketOption.SslOnConnect => SecureSocketOptions.SslOnConnect,
+            SecureSocketOption.StartTls => SecureSocketOptions.StartTls,
+            SecureSocketOption.StartTlsWhenAvailable => SecureSocketOptions.StartTlsWhenAvailable,
+            _ => SecureSocketOptions.Auto,
+        };
+        await client.ConnectAsync(settings.SMTPServer, settings.Port, secureSocketOption, cancellationToken);
 
         SaslMechanism mechanism;
 

--- a/Frends.SMTP.SendEmail/README.md
+++ b/Frends.SMTP.SendEmail/README.md
@@ -1,7 +1,6 @@
 # Frends.SMTP.SendEmail
 Frends task for sending emails with SMTP. Task sends emails via SMTP protocol and can handle attachments either from file or as raw string input.
 
-
 [![Frends.Smtp.SendEmail Main](https://github.com/FrendsPlatform/Frends.SMTP/actions/workflows/SendEmail_build_and_test_on_main.yml/badge.svg)](https://github.com/FrendsPlatform/Frends.SMTP/actions)
 ![GitHub](https://img.shields.io/github/license/FrendsPlatform/Frends.SMTP?label=License)
 ![Coverage](https://app-github-custom-badges.azurewebsites.net/Badge?key=FrendsPlatform/Frends.SMTP/Frends.SMTP.SendEmail|main)


### PR DESCRIPTION
#15 

## [1.2.0] - 2023-12-21
### Changed
- Changed Task to use MailKit library instead of deprecated System.Net.Mail.
- Changed the Task to create a temp file from the AttachmentFromString. The temp file will be removed afterwards.

### Added
- Added OAuth2 support.
- New parameters:
	- SecureSocket
	- UseOAuth2
	- Token

### Removed
- Removed UseWindowsAuthentication because it's not supported with the new library.