### PR TITLE
SMTP.SendEmail - Added AcceptAllCerts parameter

### DIFF
--- a/Frends.SMTP.SendEmail/CHANGELOG.md
+++ b/Frends.SMTP.SendEmail/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [1.3.0] - 2024-09-30
 ### Added
-- [Breaking] Added parameter AcceptAllCerts which will make the Task to accept all server certifications.
+- [Breaking] Added parameter AcceptAllCerts which allows bypassing SSL/TLS certificate validation for SMTP servers.
+	- Default value: false
+    - Warning: Enabling this option poses security risks. Only use when connecting to trusted SMTP servers with self-signed certificates.
+    - Usage: Enable only in controlled environments where certificate validation issues cannot be resolved through proper certificate installation.
 
 ## [1.2.1] - 2024-01-02
 ### Fixed

--- a/Frends.SMTP.SendEmail/CHANGELOG.md
+++ b/Frends.SMTP.SendEmail/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## [1.3.0] - 2024-09-30
+## [2.0.0] - 2024-09-30
 ### Added
 - [Breaking] Added parameter AcceptAllCerts which allows bypassing SSL/TLS certificate validation for SMTP servers.
 	- Default value: false
     - Warning: Enabling this option poses security risks. Only use when connecting to trusted SMTP servers with self-signed certificates.
     - Usage: Enable only in controlled environments where certificate validation issues cannot be resolved through proper certificate installation.
+- [Breaking] Added parameter ServerCertificationThumbprint which enables check for the certification thumbprint.
+    - Default value: ""
 
 ## [1.2.1] - 2024-01-02
 ### Fixed

--- a/Frends.SMTP.SendEmail/CHANGELOG.md
+++ b/Frends.SMTP.SendEmail/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2024-09-30
+### Added
+- [Breaking] Added parameter AcceptAllCerts which will make the Task to accept all server certifications.
+
 ## [1.2.1] - 2024-01-02
 ### Fixed
 - Fixed issue with connecting to SMTP servers which do not support authentication.

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/Frends.Smtp.Tests.csproj
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/Frends.Smtp.Tests.csproj
@@ -18,6 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+	<PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
@@ -104,19 +104,6 @@ public class SendEmailTests
     }
 
     [Test]
-    public async Task EmailTestAcceptAllCertifications()
-    {
-        _options.SecureSocket = SecureSocketOption.StartTls;
-        _options.AcceptAllCerts = true;
-
-        var input = _input;
-        input.Subject = "Email test - PlainText";
-
-        var result = await SMTP.SendEmail(input, null, _options, default);
-        Assert.IsTrue(result.EmailSent);
-    }
-
-    [Test]
     public async Task SendEmailWithFileAttachment()
     {
         var input = _input;

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail.Tests/SendEmailTests.cs
@@ -8,6 +8,8 @@ using MailKit.Net.Smtp;
 using MailKit.Security;
 using System.Net.Security;
 using System.Threading;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
 
 namespace Frends.SMTP.SendEmail.Tests;
 
@@ -256,5 +258,80 @@ public class SendEmailTests
             Assert.IsFalse(callback.Invoke(null, null, null, SslPolicyErrors.RemoteCertificateNameMismatch), "Should reject mismatched certificates");
             Assert.IsFalse(callback.Invoke(null, null, null, SslPolicyErrors.RemoteCertificateChainErrors), "Should reject invalid certificate chains");
         });
+    }
+
+    [Test]
+    public async Task TestCertificateThumbprintValidation()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=UnitTestCert", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var validCert = request.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
+        var validThumbprint = validCert.Thumbprint?.Replace(" ", "").ToUpperInvariant();
+        var invalidThumbprint = "DEADBEEF1234567890ABCDEF1234567890ABCDEF";
+
+
+        var mockSmtpClient = new Mock<SmtpClient> { CallBase = true };
+
+        mockSmtpClient.Setup(c => c.ConnectAsync(
+            It.IsAny<string>(),
+            It.IsAny<int>(),
+            It.IsAny<SecureSocketOptions>(),
+            It.IsAny<CancellationToken>()
+        )).Returns(Task.CompletedTask);
+
+        mockSmtpClient.Setup(c => c.AuthenticateAsync(
+            It.IsAny<SaslMechanism>(),
+            It.IsAny<CancellationToken>()
+        )).Returns(Task.CompletedTask);
+
+        var options = new Options
+        {
+            SMTPServer = "smtp.example.com",
+            Port = 587,
+            SecureSocket = SecureSocketOption.StartTls,
+            UseOAuth2 = false,
+        };
+
+        options.AcceptAllCerts = true;
+        options.ServerCertificationThumbprint = validThumbprint;
+
+        await SMTP.InitializeSmtpClient(options, default, mockSmtpClient.Object);
+        var callback = mockSmtpClient.Object.ServerCertificateValidationCallback;
+
+        Assert.IsTrue(
+            callback.Invoke(null, validCert, null, SslPolicyErrors.RemoteCertificateChainErrors),
+            "AcceptAllCerts=true: Valid thumbprint should be accepted."
+        );
+
+        options.ServerCertificationThumbprint = invalidThumbprint;
+
+        await SMTP.InitializeSmtpClient(options, default, mockSmtpClient.Object);
+        callback = mockSmtpClient.Object.ServerCertificateValidationCallback;
+
+        Assert.IsFalse(
+            callback.Invoke(null, validCert, null, SslPolicyErrors.RemoteCertificateChainErrors),
+            "AcceptAllCerts=true: Invalid thumbprint should be rejected."
+        );
+
+        options.AcceptAllCerts = false;
+        options.ServerCertificationThumbprint = validThumbprint;
+
+        await SMTP.InitializeSmtpClient(options, default, mockSmtpClient.Object);
+        callback = mockSmtpClient.Object.ServerCertificateValidationCallback;
+
+        Assert.IsTrue(
+            callback.Invoke(null, validCert, null, SslPolicyErrors.RemoteCertificateChainErrors),
+            "AcceptAllCerts=false: Valid thumbprint should be accepted even with SSL errors."
+        );
+
+        options.ServerCertificationThumbprint = invalidThumbprint;
+
+        await SMTP.InitializeSmtpClient(options, default, mockSmtpClient.Object);
+        callback = mockSmtpClient.Object.ServerCertificateValidationCallback;
+
+        Assert.IsFalse(
+            callback.Invoke(null, validCert, null, SslPolicyErrors.RemoteCertificateChainErrors),
+            "AcceptAllCerts=false: Invalid thumbprint should be rejected."
+        );
     }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/AssemblyInfo.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Frends.SMTP.Tests")]

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -73,10 +73,19 @@ public class Options
     public string Password { get; set; }
 
     /// <summary>
-    /// Thumbprint for server certification.
+    /// The SHA-1 thumbprint of the server's SSL certificate.
+    /// This provides a secure way to validate the server's identity without accepting all certificates.
+    /// 
+    /// How to obtain the thumbprint:
+    /// 1. View the server's certificate in a browser
+    /// 2. Open certificate details
+    /// 3. Copy the SHA-1 fingerprint/thumbprint
+    ///
+    /// Format: 40 hexadecimal characters (20 bytes)
     /// </summary>
-    /// <example></example>
+    /// <example>a1b2c3d4e5f6g7h8i9j0...</example>
     [PasswordPropertyText(true)]
     [DefaultValue("")]
+    [UIHint(nameof(AcceptAllCerts), "", false)]
     public string ServerCertificationThumbprint { get; set; }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -31,6 +31,13 @@ public class Options
     public SecureSocketOption SecureSocket { get; set; }
 
     /// <summary>
+    /// Should the task accept all certificates from IMAP server, including invalid ones?
+    /// </summary>
+    /// <example>true</example>
+    [DefaultValue(false)]
+    public bool AcceptAllCerts { get; set; }
+
+    /// <summary>
     /// Set this true if SMTP server expectes OAuth token.
     /// </summary>
     /// <example>true</example>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -71,4 +71,12 @@ public class Options
     [DefaultValue("")]
     [UIHint(nameof(UseOAuth2), "", false)]
     public string Password { get; set; }
+
+    /// <summary>
+    /// Thumbprint for server certification.
+    /// </summary>
+    /// <example></example>
+    [PasswordPropertyText(true)]
+    [DefaultValue("")]
+    public string ServerCertificationThumbprint { get; set; }
 }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -31,7 +31,9 @@ public class Options
     public SecureSocketOption SecureSocket { get; set; }
 
     /// <summary>
-    /// Should the task accept all certificates from IMAP server, including invalid ones?
+    /// WARNING: Setting AcceptAllCerts to true disables SSL/TLS certificate validation.
+    /// This should only be used in development/test environments with self-signed certificates.
+    /// Using this option in production environments poses significant security risks.
     /// </summary>
     /// <example>true</example>
     [DefaultValue(false)]

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Definitions/Options.cs
@@ -35,7 +35,7 @@ public class Options
     /// This should only be used in development/test environments with self-signed certificates.
     /// Using this option in production environments poses significant security risks.
     /// </summary>
-    /// <example>true</example>
+    /// <example>false</example>
     [DefaultValue(false)]
     public bool AcceptAllCerts { get; set; }
 

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
   <TargetFramework>net6.0</TargetFramework>
-	<Version>1.3.0</Version>
+	<Version>2.0.0</Version>
 	<LangVersion>latest</LangVersion>
 	<Authors>Frends</Authors>
 	<Company>Frends</Company>
@@ -31,11 +31,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
 
 </Project>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/Frends.Smtp.SendEmail.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
   <TargetFramework>net6.0</TargetFramework>
-	<Version>1.2.1</Version>
+	<Version>1.3.0</Version>
 	<LangVersion>latest</LangVersion>
 	<Authors>Frends</Authors>
 	<Company>Frends</Company>
@@ -31,5 +31,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+			<_Parameter1>$(MSBuildProjectName).Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
 
 </Project>

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Frends.SMTP.SendEmail.Definitions;
 using System.Runtime.CompilerServices;
+using System.Net.Security;
 
 [assembly: InternalsVisibleTo("Frends.SMTP.Tests")]
 namespace Frends.SMTP.SendEmail;
@@ -108,6 +109,10 @@ public static class SMTP
 #pragma warning disable S4830 // Server certificates should be verified during SSL/TLS connections
             client.ServerCertificateValidationCallback = (s, x509certificate, x590chain, sslPolicyErrors) => true;
 #pragma warning restore S4830 // Server certificates should be verified during SSL/TLS connections
+        }
+        else
+        {
+            client.ServerCertificateValidationCallback = (s, x509certificate, x590chain, sslPolicyErrors) => sslPolicyErrors == SslPolicyErrors.None;
         }
 
         var secureSocketOption = options.SecureSocket switch

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -6,16 +6,15 @@ using System.Linq;
 using System.Net;
 using MailKit.Net.Smtp;
 using MailKit.Security;
+using System.Security.Cryptography.X509Certificates;
 using MimeKit;
 using MimeKit.Text;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Frends.SMTP.SendEmail.Definitions;
-using System.Runtime.CompilerServices;
 using System.Net.Security;
 
-[assembly: InternalsVisibleTo("Frends.SMTP.Tests")]
 namespace Frends.SMTP.SendEmail;
 /// <summary>
 /// Main class of the Task.
@@ -112,7 +111,18 @@ public static class SMTP
         }
         else
         {
-            client.ServerCertificateValidationCallback = (s, x509certificate, x590chain, sslPolicyErrors) => sslPolicyErrors == SslPolicyErrors.None;
+            client.ServerCertificateValidationCallback = (s, x509certificate, x590chain, sslPolicyErrors) =>
+            {
+                if (!string.IsNullOrEmpty(options.ServerCertificationThumbprint))
+                {
+                    if (x509certificate is X509Certificate2 cert && options.ServerCertificationThumbprint == cert.Thumbprint)
+                        return true;
+                    else
+                        return false;
+                }
+                
+                return sslPolicyErrors == SslPolicyErrors.None;
+            };
         }
 
         var secureSocketOption = options.SecureSocket switch

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -144,13 +144,13 @@ public static class SMTP
         var separators = new[] { ',', ';' };
 
         MailboxAddress[] recipients = string.IsNullOrEmpty(input.To)
-            ? []
+            ? Array.Empty<MailboxAddress>()
             : input.To.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(x => MailboxAddress.Parse(x)).ToArray();
         MailboxAddress[] ccRecipients = string.IsNullOrEmpty(input.Cc)
-            ? []
+            ? Array.Empty<MailboxAddress>()
             : input.Cc.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(x => MailboxAddress.Parse(x)).ToArray();
         MailboxAddress[] bccRecipients = string.IsNullOrEmpty(input.Bcc)
-            ? []
+            ? Array.Empty<MailboxAddress>()
             : input.Bcc.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(x => MailboxAddress.Parse(x)).ToArray();
 
         //Create mail object

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -120,7 +120,7 @@ public static class SMTP
                     else
                         return false;
                 }
-                
+
                 return sslPolicyErrors == SslPolicyErrors.None;
             };
         }

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -106,7 +106,21 @@ public static class SMTP
         if (options.AcceptAllCerts)
         {
 #pragma warning disable S4830 // Server certificates should be verified during SSL/TLS connections
-            client.ServerCertificateValidationCallback = (s, x509certificate, x590chain, sslPolicyErrors) => true;
+            client.ServerCertificateValidationCallback = (s, x509certificate, x590chain, sslPolicyErrors) =>
+            {
+                if (!string.IsNullOrEmpty(options.ServerCertificationThumbprint))
+                {
+                    if (x509certificate is X509Certificate2 cert && options.ServerCertificationThumbprint == cert.Thumbprint)
+                        return true;
+                    else
+                        return false;
+                }
+                else
+                {
+                    return true;
+                }
+
+            };
 #pragma warning restore S4830 // Server certificates should be verified during SSL/TLS connections
         }
         else

--- a/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
+++ b/Frends.SMTP.SendEmail/Frends.Smtp.SendEmail/SendEmailTask.cs
@@ -110,7 +110,10 @@ public static class SMTP
             {
                 if (!string.IsNullOrEmpty(options.ServerCertificationThumbprint))
                 {
-                    if (x509certificate is X509Certificate2 cert && options.ServerCertificationThumbprint == cert.Thumbprint)
+                    if (x509certificate is X509Certificate2 cert && string.Equals(
+                        options.ServerCertificationThumbprint?.Replace(" ", "").ToUpperInvariant(),
+                        cert.Thumbprint?.Replace(" ", "").ToUpperInvariant(),
+                        StringComparison.Ordinal))
                         return true;
                     else
                         return false;
@@ -129,7 +132,10 @@ public static class SMTP
             {
                 if (!string.IsNullOrEmpty(options.ServerCertificationThumbprint))
                 {
-                    if (x509certificate is X509Certificate2 cert && options.ServerCertificationThumbprint == cert.Thumbprint)
+                    if (x509certificate is X509Certificate2 cert && string.Equals(
+                        options.ServerCertificationThumbprint?.Replace(" ", "").ToUpperInvariant(),
+                        cert.Thumbprint?.Replace(" ", "").ToUpperInvariant(),
+                        StringComparison.Ordinal))
                         return true;
                     else
                         return false;


### PR DESCRIPTION
#25 #28 

## [2.0.0] - 2024-09-30
### Added
- [Breaking] Added parameter AcceptAllCerts which will make the Task to accept all server certifications.
    - Default value: false
    - Warning: Enabling this option poses security risks. Only use when connecting to trusted SMTP servers with self-signed certificates.
    - Usage: Enable only in controlled environments where certificate validation issues cannot be resolved through proper certificate installation.
- [Breaking] Added parameter ServerCertificationThumbprint which enables check for the certification thumbprint.
    - Default value: ""

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ServerCertificationThumbprint parameter for thumbprint-based server certificate checks.
  - Added AcceptAllCerts parameter (default false) to allow bypassing SSL/TLS cert validation (security warning).

- **Bug Fixes**
  - Improved connection handling for SMTP servers that do not require authentication.

- **Tests**
  - Added tests covering AcceptAllCerts and certificate thumbprint validation scenarios (mocking/support added).

- **Documentation**
  - Changelog updated for version 2.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->